### PR TITLE
The latest apt module wants the full key

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -23,6 +23,6 @@ class percona_repo::apt {
     location => 'http://repo.percona.com/apt',
     release => $::lsbdistcodename,
     repos => 'main',
-    key => "CD2EFD2A",
+    key => '430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A',
   }
 }


### PR DESCRIPTION
The apt module now complains if the key isn't the full fingerprint. Warning: /Apt_key[Add key: CD2EFD2A from Apt::Source percona]: The id should be a full fingerprint (40 characters), see README.
